### PR TITLE
Add ca-certificates to analyzer docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV APP_DOWNLOAD_URL https://dl.bintray.com/epam/reportportal/5.0.0-RC-1
 
 ADD ${APP_DOWNLOAD_URL}/service-analyzer_linux_amd64 /service-analyzer
 
-RUN chmod +x /service-analyzer
-
+RUN chmod +x /service-analyzer && \
+    apk add --no-cache ca-certificates
 
 EXPOSE 8080
 ENTRYPOINT ["/service-analyzer"]

--- a/DockerfileTmpl
+++ b/DockerfileTmpl
@@ -7,8 +7,8 @@ ENV APP_DOWNLOAD_URL https://dl.bintray.com/epam/reportportal/{{.version}}
 
 ADD ${APP_DOWNLOAD_URL}/service-analyzer_linux_amd64 /service-analyzer
 
-RUN chmod +x /service-analyzer
-
+RUN chmod +x /service-analyzer && \
+    apk add --no-cache ca-certificates
 
 EXPOSE 8080
 ENTRYPOINT ["/service-analyzer"]


### PR DESCRIPTION
We've been having some issues connecting to our elasticsearch cluster (we're using the AWS managed service).  We're using service-analyzer v4.3.0 with reportportal v4. The error we're having is:

```
[2019-10-15 09:41:54] ERROR Cannot send request to ES: Get https://vpc-reportportal-somerandomhash.eu-west-1.es.amazonaws.com:443/_cluster/health: x509: failed to load system roots and no roots provided
```

Adding the ca-certificates (like also have in `DockerfileDev`) fixed it for us.